### PR TITLE
Client connection degrades over time and finally only timeouts will b…

### DIFF
--- a/client_request.go
+++ b/client_request.go
@@ -44,7 +44,7 @@ func newClientRequest(client *Client) *clientRequest {
 		),
 
 		// vars
-		done:  make(chan struct{}),
+		done:  make(chan struct{}, 1),
 		args:  make([]interface{}, 0),
 		reply: make([]interface{}, 0),
 	}


### PR DESCRIPTION
…e possible.

If request/call ends with timeout by some reason, and later server return reply. client's reading routine will be blocked on `request.done` channel forever, this effectively blocks any communication. We can mitigate such failure with buffered channel.